### PR TITLE
Handle default preferences as array

### DIFF
--- a/assistedDriving/public/assets/js/userProfile.js
+++ b/assistedDriving/public/assets/js/userProfile.js
@@ -80,6 +80,7 @@ async function createNewProfile() {
             const userData = await response.json();
             localStorage.setItem('userName', name);
             localStorage.setItem('userCode', userData.identification_code);
+            handlePreferencesRedirect(JSON.stringify(userData.preferences || []));
 
             document.querySelector('.welcome h1').innerHTML =
                 `<img src="../../assets/icons/welcome/Profile.svg" class="welcome-icon" alt=""> Willkommen ${name}!`;
@@ -191,9 +192,10 @@ async function showExistingProfiles() {
         if (result.isConfirmed) {
             const response = await fetch(`/api/users/${result.value}`);
             const selectedProfile = await response.json();
-
+            
             localStorage.setItem('userCode', result.value);
             localStorage.setItem('userName', selectedProfile.name);
+            handlePreferencesRedirect(JSON.stringify(selectedProfile.preferences || []));
 
             document.querySelector('.welcome h1').innerHTML =
                 `<img src="../../assets/icons/welcome/Profile.svg" class="welcome-icon" alt=""> Willkommen ${selectedProfile.name}!`;
@@ -232,5 +234,21 @@ async function showExistingProfiles() {
                 container: 'swal-container-custom'
             }
         });
+    }
+}
+
+function handlePreferencesRedirect(prefsString) {
+    let prefs;
+    try {
+        prefs = JSON.parse(prefsString);
+        if (!Array.isArray(prefs)) {
+            prefs = [];
+        }
+    } catch (e) {
+        prefs = [];
+    }
+    localStorage.setItem('preferences', JSON.stringify(prefs));
+    if (prefs.length === 0) {
+        window.location.href = '/views/preferences';
     }
 }

--- a/assistedDriving/server.js
+++ b/assistedDriving/server.js
@@ -25,6 +25,7 @@ const db = new sqlite3.Database('users.db', (err) => {
             name TEXT NOT NULL,
             total_progress INTEGER DEFAULT 0,
             unlocked_categories TEXT DEFAULT '[]',
+            preferences TEXT DEFAULT '[]',
             total_bonusPoints_score INTEGER DEFAULT 0 CHECK (total_bonusPoints_score >= 0 AND total_bonusPoints_score <= 100),
             assistance_kilometer INTEGER DEFAULT 0,
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP
@@ -92,8 +93,8 @@ app.post('/api/users', (req, res) => {
     const {name, identificationCode} = req.body;
 
     db.run(
-        `INSERT INTO profiles (identification_code, name, unlocked_categories, total_bonusPoints_score, assistance_kilometer) VALUES (?, ?, ?, 0, 0)`,
-        [identificationCode, name, JSON.stringify([])],
+        `INSERT INTO profiles (identification_code, name, unlocked_categories, preferences, total_bonusPoints_score, assistance_kilometer) VALUES (?, ?, ?, ?, 0, 0)`,
+        [identificationCode, name, JSON.stringify([]), JSON.stringify([])],
         function (err) {
             if (err) {
                 res.status(400).json({error: err.message});
@@ -103,6 +104,7 @@ app.post('/api/users', (req, res) => {
             res.json({
                 identification_code: identificationCode,
                 name: name,
+                preferences: [],
                 total_bonusPoints_score: 0,
                 assistance_kilometer: 0
             });


### PR DESCRIPTION
## Summary
- default preferences to JSON array
- ensure `handlePreferencesRedirect` validates stored value as an array
- store preferences on login/creation and redirect if none

## Testing
- `npm test --prefix assistedDriving` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c002cf2448321b8fb3e9ef32aa118